### PR TITLE
docs(editor): clarify content prop comment

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -53,7 +53,7 @@ const CalloutDirectiveDescriptor: DirectiveDescriptor = {
 }
 
 type StringProps = {
-  content: string; // Replace 'string' with the actual type of 'content'
+  content: string; // MDX markdown source as a string
   onContentChange: (mdxEditor: React.RefObject<MDXEditorMethods | null>) => void;
 };
 


### PR DESCRIPTION
## Summary
- clarify `content` comment in Editor component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956f73b7808323942c2c575dfbf989