### PR TITLE
test: add nonAccentVietnamese unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@mdxeditor/editor": "^3.29.1",
@@ -41,6 +42,7 @@
     "@types/react-dom": "^19.0.4",
     "eslint": "^9.23.0",
     "eslint-config-next": "15.2.4",
+    "vitest": "^1.6.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.2"

--- a/src/libs/nonAccentVietnamese.test.ts
+++ b/src/libs/nonAccentVietnamese.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import ToNonAccentVietnamese, { ConvertToNameFormat } from "./nonAccentVietnamese";
+
+describe("ToNonAccentVietnamese", () => {
+  it("removes Vietnamese accents", () => {
+    expect(ToNonAccentVietnamese("Đặng")).toBe("Dang");
+    expect(ToNonAccentVietnamese("Trần")).toBe("Tran");
+  });
+});
+
+describe("ConvertToNameFormat", () => {
+  it("formats text to slug-style", () => {
+    expect(ConvertToNameFormat("Hello World!")).toBe("Hello-World");
+  });
+});
+

--- a/src/libs/nonAccentVietnamese.ts
+++ b/src/libs/nonAccentVietnamese.ts
@@ -26,7 +26,8 @@ const ConvertToNameFormat = (str: string) => {
     str = str.replace(/\s-+/g, "-");
     str = str.replaceAll(' ', '-');
     return str.trim();
-}
+};
+
 export default ToNonAccentVietnamese;
 
-export {ConvertToNameFormat, ToNonAccentVietnamese };
+export { ConvertToNameFormat, ToNonAccentVietnamese };

--- a/src/pages/editor/edit/[id].tsx
+++ b/src/pages/editor/edit/[id].tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/router";
 import { HostBackend } from "@/libs/contanst";
 import { getCookie } from "cookies-next";
 import Tabs from "@/components/Tabs";
-import { ConvertToNameFormat, ToNonAccentVietnamese } from "@/libs/ nonAccentVietnamese";
+import { ConvertToNameFormat, ToNonAccentVietnamese } from "@/libs/nonAccentVietnamese";
 import { AdmonitionDirectiveDescriptor, BoldItalicUnderlineToggles, ChangeAdmonitionType, ChangeCodeMirrorLanguage, codeMirrorPlugin, CodeToggle, ConditionalContents, diffSourcePlugin, DiffSourceToggleWrapper, DirectiveDescriptor, directivesPlugin, frontmatterPlugin, GenericDirectiveEditor, imagePlugin, InsertCodeBlock, InsertFrontmatter, InsertImage, InsertSandpack, InsertTable, InsertThematicBreak, KitchenSinkToolbar, linkDialogPlugin, ListsToggle, MDXEditorMethods, ShowSandpackInfo, tablePlugin, UndoRedo, type CodeBlockEditorDescriptor, type SandpackConfig } from '@mdxeditor/editor';
 import FrontMatterMdxForm, { FrontMatterMdx } from "./form";
 


### PR DESCRIPTION
## Summary
- rename nonAccentVietnamese util and add vitest tests for accent removal and slug formatting
- configure vitest test script in package.json

## Testing
- `pnpm install` *(fails: No authorization header was set for the request)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689570e9def08323863fb3190dad6db9