### PR TITLE
fix: guard undefined display name

### DIFF
--- a/src/pages/editor/edit/[id].tsx
+++ b/src/pages/editor/edit/[id].tsx
@@ -117,7 +117,8 @@ const Editor =  () =>{
           setMdxContent(bodyJson.content);
           setMdxFrontMatter(bodyJson.frontMatter);
           mdxEditorRef.current?.setMarkdown(bodyJson.content)
-          setName(bodyJson.display_name.replaceAll('.mdx', ''));
+          // display_name might be missing which would cause a runtime error when calling replaceAll
+          setName(bodyJson.display_name?.replaceAll('.mdx', '') || '');
         }
         setLoading(false);
       };


### PR DESCRIPTION
## Summary
- avoid runtime crash when `display_name` is missing by guarding before calling `replaceAll`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: waiting for file changes, exit code after cancel)*
- `pnpm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6895739c618c832387cc58df009045d7