### PR TITLE
fix: handle missing tags in editor form

### DIFF
--- a/src/pages/editor/edit/form.tsx
+++ b/src/pages/editor/edit/form.tsx
@@ -30,8 +30,12 @@ export default function FrontMatterMdxForm(props : FormProps) {
   const [formData, setFormData] = useState<FrontMatterMdx>({heroImage:"",category:"",description:"",pubDate:"",tags: [],title:"",  tagsAsInput: ""});
   useEffect(()=>{
     if (props.data) {
-      props.data.tagsAsInput = props.data.tags.join(",");
-      setFormData(props.data);
+      const tags = props.data.tags ?? [];
+      props.data.tagsAsInput = tags.join(",");
+      setFormData({
+        ...props.data,
+        tags,
+      });
     }
   }, [props.data])
  


### PR DESCRIPTION
## Summary
- avoid crashing editor form when front matter is missing tags

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68957ac2a2648323b6b50e0476a7733e